### PR TITLE
Fea 46 task 66

### DIFF
--- a/docker-aoi-apache/apache_config/httpd.conf
+++ b/docker-aoi-apache/apache_config/httpd.conf
@@ -53,6 +53,14 @@ Listen 80
 
 ServerName aoi.default.server
 
+ProxyPass "/v1/aoi/api/users" "http://aoi:8080/v1/aoi/api/users"
+ProxyPassReverse "/v1/aoi/api/users" "http://aoi:8080/v1/aoi/api/users"
+
+ProxyPass "/v1/aoi/api/another" "http://aoi:8080/v1/aoi/api/another"
+ProxyPassReverse "/v1/aoi/api/another" "http://aoi:8080/v1/aoi/api/another"
+
+ProxyPass "/v1/aoi/api/example" "http://aoi:8080/v1/aoi/api/example"
+ProxyPassReverse "/v1/aoi/api/example" "http://aoi:8080/v1/aoi/api/example"
 
 #
 # Dynamic Shared Object (DSO) Support

--- a/docker-aoi-compose/docker-compose.yaml
+++ b/docker-aoi-compose/docker-compose.yaml
@@ -15,6 +15,8 @@ services:
                 image: mysql
                 networks:
                         - aoinet
-                command: tail -F anything
+                command: --default-authentication-plugin=mysql_native_password
+                environment:
+                        MYSQL_ROOT_PASSWORD: example
 networks:
         aoinet:

--- a/docker-aoi-compose/docker-compose.yaml
+++ b/docker-aoi-compose/docker-compose.yaml
@@ -10,7 +10,7 @@ services:
                 build: ../rest-server/
                 networks:
                         - aoinet
-                command: tail -F anything 
+                tty: true
         db:
                 image: mysql
                 networks:

--- a/docker-aoi-compose/docker-compose.yaml
+++ b/docker-aoi-compose/docker-compose.yaml
@@ -1,0 +1,20 @@
+version: "3"
+services:
+        apache:
+                build: ../docker-aoi-apache
+                ports:
+                        - "8080:80"
+                networks:
+                        - aoinet
+        aoi:
+                build: ../rest-server/
+                networks:
+                        - aoinet
+                command: tail -F anything 
+        db:
+                image: mysql
+                networks:
+                        - aoinet
+                command: tail -F anything
+networks:
+        aoinet:

--- a/rest-server/test
+++ b/rest-server/test
@@ -1,0 +1,1 @@
+{"status":"ready!","version":"0.1.1"}


### PR DESCRIPTION
Docker compose operational. The only issue is that you will have to go start the rest-server manually.

This can be done via: 
docker exec -it -d docker-aoi-compose_aoi_whatever_randomness_it_gens /usr/src/aoi-rest-server/build/aoi-rest-server

Not an ideal solution yet, however, it does function and all the proxy requests go to the correct locations.